### PR TITLE
currency: update Zambian kwacha ZMK to ZMW

### DIFF
--- a/currency.js
+++ b/currency.js
@@ -387,7 +387,7 @@
       'XCD': [2, '$', 'EC$'],
       'XOF': [0, 'CFA', 'CFA'],
       'XPF': [0, 'FCFP', 'FCFP'],
-      'ZMK': [0, 'ZMK', 'ZMK']
+      'ZMW': [0, 'ZMW', 'ZMW']
     };
 
     if (typeof exports !== 'undefined') {


### PR DESCRIPTION
The Zambian kwacha was [rebased in 2013]( https://en.wikipedia.org/wiki/Zambian_kwacha#2013_rebasing) and changed their ISO code to `ZMW`.

r? @SlexAxton 